### PR TITLE
Remove bit-smasher dependency

### DIFF
--- a/lmdb.asd
+++ b/lmdb.asd
@@ -8,8 +8,7 @@
   :source-control (:git "git@github.com:antimer/lmdb.git")
   :depends-on (:liblmdb
                :alexandria
-               :trivial-utf-8
-               :bit-smasher)
+               :trivial-utf-8)
   :components ((:module "src"
                 :components
                 ((:file "lmdb"))))

--- a/src/lmdb.lisp
+++ b/src/lmdb.lisp
@@ -169,12 +169,14 @@ floats, booleans and strings. Returns a (size . array) pair."
     (vector
      (cons (length data) data))
     (integer
-     (let ((octets (bit-smasher:int->octets data)))
+     (let ((octets (integer-to-octets data)))
        (cons (length octets) octets)))
     (boolean
      (cons 1 (if data 1 0)))
     (t
      (error "Invalid type."))))
+
+
 
 (defun make-value (data)
   "Create a value object."
@@ -583,6 +585,16 @@ is closed."
                      ,value tv))))))))
 
 ;;; Utilities
+
+(defun integer-to-octets (bignum &aux (n-bits (integer-length bignum)))
+  (let* ((n-bytes (ceiling n-bits 8))
+         (octet-vec (make-array n-bytes :element-type '(unsigned-byte 8))))
+    (declare (type (simple-array (unsigned-byte 8)) octet-vec))
+    (loop
+       :for i :from (1- n-bytes) :downto 0
+       :for index :from 0
+       :do (setf (aref octet-vec index) (ldb (byte 8 (* i 8)) bignum))
+       :finally (return octet-vec))))
 
 (defun version-string ()
   "Return the version string."


### PR DESCRIPTION
Adding this library to the vendored third-party libraries in a project requires adding bit-smasher lib too, while the only used part of it is `int->octets` function, which is itself copied from `ironclad` library in `bit-smasher`. As it is small enough, I included it in `;; Utilities` definitions. Fewer external deps is better, so, if it aligns with your view of the project, it can be merged in.

Note: the same holds for `trivial-utf-8` library, but that function is bigger and more tightly coupled with the rest of the lib, so I left it out.