### PR TITLE
Enhance CURSOR-GET to support :SET, :SET-KEY, and :SET-RANGE.

### DIFF
--- a/lmdb-test.asd
+++ b/lmdb-test.asd
@@ -1,4 +1,4 @@
-(defsystem lmdb-test
+(asdf:defsystem lmdb-test
   :author "Fernando Borretti <eudoxiahp@gmail.com>"
   :license "MIT"
   :depends-on (:lmdb

--- a/lmdb.asd
+++ b/lmdb.asd
@@ -1,4 +1,4 @@
-(defsystem lmdb
+(asdf:defsystem lmdb
   :author "Fernando Borretti <eudoxiahp@gmail.com>"
   :maintainer "Fernando Borretti <eudoxiahp@gmail.com>"
   :license "MIT"


### PR DESCRIPTION
Add a test to the test-suite for :SET-RANGE.

Fix a bug in CLOSE-CURSOR, it was calling LIBLMDB:CURSOR-CLOSE on the handle, not its contents.

Make each of the test suite tests initialize its data. They are run in basically random order, so none can depend on any others.

(lmdb:run-tests) now works as expected.